### PR TITLE
Allow space-separated PEDs; skip variants missing required format fields

### DIFF
--- a/synthdnm/backend.py
+++ b/synthdnm/backend.py
@@ -1,21 +1,36 @@
 import re
+
 # Splits a line by spaces or tabs, returns a list object
 def tokenize(line):
     linesplit = line.rstrip().split("\t")
-    if len(linesplit) == 1: linesplit = line.rstrip().split(" ")
-    else: return linesplit
+    if len(linesplit) == 1:
+        linesplit = line.rstrip().split(" ")
+    return linesplit
+
 
 # Returns dictionary containing information of pedigree file
 def process_ped(fam_filepath):
-    ped_dictionary = {} # ped_dictionary[iid] = (fid, iid, father_iid, mother_iid, sex, phen)
+    ped_dictionary = (
+        {}
+    )  # ped_dictionary[iid] = (fid, iid, father_iid, mother_iid, sex, phen)
     with open(fam_filepath) as f:
         for line in f:
             linesplit = tokenize(line)
-            fid,iid,father_iid,mother_iid,sex,phen = linesplit[0],linesplit[1],linesplit[2],linesplit[3],linesplit[4],linesplit[5]
-            if sex != "1" and sex != "2": continue
-            if father_iid == "0" and mother_iid == "0": continue
-            ped_dictionary[iid] = (fid,iid,father_iid,mother_iid,sex,phen)
+            fid, iid, father_iid, mother_iid, sex, phen = (
+                linesplit[0],
+                linesplit[1],
+                linesplit[2],
+                linesplit[3],
+                linesplit[4],
+                linesplit[5],
+            )
+            if sex != "1" and sex != "2":
+                continue
+            if father_iid == "0" and mother_iid == "0":
+                continue
+            ped_dictionary[iid] = (fid, iid, father_iid, mother_iid, sex, phen)
     return ped_dictionary
+
 
 # Convert spaces to tabs
 def tabbit(line):

--- a/synthdnm/clf.py
+++ b/synthdnm/clf.py
@@ -1,5 +1,5 @@
-__version__="0.1.0.1"
-__usage__="""
+__version__ = "0.1.0.1"
+__usage__ = """
  _______  __   __  __    _  _______  __   __  ______   __    _  __   __ 
 |       ||  | |  ||  |  | ||       ||  | |  ||      | |  |  | ||  |_|  |
 |  _____||  |_|  ||   |_| ||_     _||  |_|  ||  _    ||   |_| ||       |
@@ -28,63 +28,92 @@ optional arguments:
   
   -h, --help           show this message and exit
      
-""".format(__version__)
-
+""".format(
+    __version__
+)
 
 
 import pandas as pd
+
 # from sklearn.externals import joblib
 import joblib
-import os,sys
+import os, sys
 import numpy as np
 
-def classify_dataframe(df = None, clf = None, ofh = None, mode = "a", keep_fp = False, features = None):
+
+def classify_dataframe(
+    df=None, clf=None, ofh=None, mode="a", keep_fp=False, features=None
+):
     pd.options.mode.chained_assignment = None
     df = df.replace([np.inf, -np.inf], np.nan)
-    df = df.dropna(axis=0,subset=df.columns[12:36])
+    df = df.dropna(axis=0, subset=df.columns[12:36])
 
     # ClippingRankSum (temporary solution)
     df["ClippingRankSum"] = 0
 
-    if df.empty: 
+    if df.empty:
         # print("Empty dataframe.")
         return 0
 
     X = df[features].to_numpy()
 
     df["pred"] = clf.predict(X)
-    df["prob"] = clf.predict_proba(X)[:,1]
+    df["prob"] = clf.predict_proba(X)[:, 1]
 
     if keep_fp == False:
         df = df.loc[df["pred"] == 1]
 
     with open(ofh, mode) as f:
-        df.to_csv(f, sep="\t", header = False, index=False)
+        df.to_csv(f, sep="\t", header=False, index=False)
+
 
 def get_sex(fam_fh):
     fam = open(fam_fh, "r")
     fam_dict = {}
     for line in fam:
         linesplit = line.rstrip().split("\t")
+        if len(linesplit) == 1:
+            linesplit = linesplit[0].split(" ")
         iid = linesplit[1]
         sex = linesplit[4]
-        fam_dict[iid] = sex 
+        fam_dict[iid] = sex
     df = pd.Series(fam_dict).to_frame("sex")
     df["iid"] = df.index
     df.reset_index(inplace=True)
-    df.drop(columns=["index"],inplace=True)
+    df.drop(columns=["index"], inplace=True)
     return df
 
-def classify(feature_table=None,keep_fp=False,pseud=None,fam_fh=None,clf_snv="snp_100-12-10-2-1-0.0-100.joblib",clf_indel="indel_1000-12-25-2-1-0.0-100.joblib"):
+
+def classify(
+    feature_table=None,
+    keep_fp=False,
+    pseud=None,
+    fam_fh=None,
+    clf_snv="snp_100-12-10-2-1-0.0-100.joblib",
+    clf_indel="indel_1000-12-25-2-1-0.0-100.joblib",
+):
     # Get classifiers
     clf = joblib.load(clf_snv)
     clf_indels = joblib.load(clf_indel)
-    
+
     # Make dataframe from input pydnm file
-    df = pd.read_csv(feature_table,sep="\t",dtype={"chrom": str})
+    df = pd.read_csv(feature_table, sep="\t", dtype={"chrom": str})
     # Get the list of features
     columns = list(df.columns)
-    non_features = ['chrom', 'pos', 'ID', 'ref', 'alt', 'iid', 'offspring_gt', 'father_gt', 'mother_gt', 'nalt', 'filter', 'qual']
+    non_features = [
+        "chrom",
+        "pos",
+        "ID",
+        "ref",
+        "alt",
+        "iid",
+        "offspring_gt",
+        "father_gt",
+        "mother_gt",
+        "nalt",
+        "filter",
+        "qual",
+    ]
     features = [elem for elem in columns if elem not in non_features]
 
     df_fam = get_sex(fam_fh)
@@ -96,32 +125,47 @@ def classify(feature_table=None,keep_fp=False,pseud=None,fam_fh=None,clf_snv="sn
     # pseud_chrY_interval_one = pseud_chrY[0]
     # pseud_chrY_interval_two = pseud_chrY[1]
 
-    
     from pathlib import Path
+
     feature_filename = feature_table
     feature_file_stem = Path(feature_filename).stem
     feature_file_parent = str(Path(feature_filename).parent) + "/"
-    feature_file_parent_stem = feature_file_parent + feature_file_stem 
+    feature_file_parent_stem = feature_file_parent + feature_file_stem
     ofh = feature_file_parent_stem + ".preds.txt"
 
     with open(feature_filename) as f:
         header_list = f.readline().rstrip().split("\t")
-    header_list = header_list + ["sex","pred","prob"]
+    header_list = header_list + ["sex", "pred", "prob"]
 
-    df_out = pd.DataFrame(columns = header_list)
-    df_out.to_csv(ofh, sep = "\t", index = False)
-    
-    df['iid']=df['iid'].astype(str)
-    df_fam['iid']=df_fam['iid'].astype(str)
+    df_out = pd.DataFrame(columns=header_list)
+    df_out.to_csv(ofh, sep="\t", index=False)
+
+    df["iid"] = df["iid"].astype(str)
+    df_fam["iid"] = df_fam["iid"].astype(str)
     df = pd.merge(df, df_fam, on="iid")
-    df=df[~df["chrom"].str.contains("GL*")]
-    df["chrom"]=df["chrom"].astype(str)
-    df["chrom"] = df["chrom"].apply(lambda s: "chr" + s if not s.startswith("chr") else s)
+    df = df[~df["chrom"].str.contains("GL*")]
+    df["chrom"] = df["chrom"].astype(str)
+    df["chrom"] = df["chrom"].apply(
+        lambda s: "chr" + s if not s.startswith("chr") else s
+    )
 
-
-    df_autosomal_SNV = df.loc[(df["chrom"] != "chrY") & (df["chrom"] != "chrX") &(df["offspring_gt"]=='0/1') & (df["mother_gt"]=='0/0') &(df["father_gt"]=='0/0') & (df["ref"].str.len() == 1) & (df["alt"].str.len() == 1)]
-    df_autosomal_indel = df.loc[(df["chrom"] != "chrY") & (df["chrom"] != "chrX") &(df["offspring_gt"]=='0/1') & (df["mother_gt"]=='0/0') &(df["father_gt"]=='0/0')& ((df["ref"].str.len() != 1) | (df["alt"].str.len() != 1))]
-
+    df_autosomal_SNV = df.loc[
+        (df["chrom"] != "chrY")
+        & (df["chrom"] != "chrX")
+        & (df["offspring_gt"] == "0/1")
+        & (df["mother_gt"] == "0/0")
+        & (df["father_gt"] == "0/0")
+        & (df["ref"].str.len() == 1)
+        & (df["alt"].str.len() == 1)
+    ]
+    df_autosomal_indel = df.loc[
+        (df["chrom"] != "chrY")
+        & (df["chrom"] != "chrX")
+        & (df["offspring_gt"] == "0/1")
+        & (df["mother_gt"] == "0/0")
+        & (df["father_gt"] == "0/0")
+        & ((df["ref"].str.len() != 1) | (df["alt"].str.len() != 1))
+    ]
 
     # df_female_X_SNV = df.loc[(df["chrom"] == "chrX") & (df["sex"] == "2") & (df["offspring_gt"]=='0/1') & (df["mother_gt"]=='0/0') &(df["father_gt"]=='0/0') & (df["ref"].str.len() == 1) & (df["alt"].str.len() == 1)]
     # df_female_X_indel = df.loc[(df["chrom"] == "chrX") & (df["sex"] == "2") &(df["offspring_gt"]=='0/1') & (df["mother_gt"]=='0/0') &(df["father_gt"]=='0/0') & ((df["ref"].str.len() != 1) | (df["alt"].str.len() != 1))]
@@ -134,53 +178,69 @@ def classify(feature_table=None,keep_fp=False,pseud=None,fam_fh=None,clf_snv="sn
     # df_male_PAR_X_indel = df.loc[(df["chrom"] == "chrX") & (df["sex"] == "1") & (df["offspring_gt"]=='0/1') & (df["mother_gt"]=='0/0') &(df["father_gt"]=='0/0')& ((df["ref"].str.len() != 1) | (df["alt"].str.len() != 1)) & (df["pos"].between(pseud_chrX_interval_one[0],pseud_chrX_interval_one[1]) | df["pos"].between(pseud_chrX_interval_two[0], pseud_chrX_interval_two[1]))]
     # df_male_PAR_Y_indel = df.loc[(df["chrom"] == "chrY") & (df["sex"] == "1") &(df["offspring_gt"]=='0/1') &(df["mother_gt"]=='0/0') &(df["father_gt"]=='0/0')& ((df["ref"].str.len() != 1) | (df["alt"].str.len() != 1)) & (df["pos"].between(pseud_chrY_interval_one[0],pseud_chrY_interval_one[1]) | df["pos"].between(pseud_chrY_interval_two[0], pseud_chrY_interval_two[1]))]
 
-
-
-    classify_dataframe(df = df_autosomal_SNV, clf = clf, ofh = ofh, features = features, keep_fp = keep_fp)
-    classify_dataframe(df = df_autosomal_indel,clf = clf_indels, ofh = ofh, features = features, keep_fp = keep_fp)
-
+    classify_dataframe(
+        df=df_autosomal_SNV, clf=clf, ofh=ofh, features=features, keep_fp=keep_fp
+    )
+    classify_dataframe(
+        df=df_autosomal_indel,
+        clf=clf_indels,
+        ofh=ofh,
+        features=features,
+        keep_fp=keep_fp,
+    )
 
     # classify_dataframe(df_female_X_SNV,clf,ofh_new)
     # classify_dataframe(df_female_X_indel,clf_indels,ofh_new)
     # classify_dataframe(df_male_nonPAR_X_SNV,clf_chrX_snps,ofh_new)
-    # classify_dataframe(df_male_nonPAR_Y_SNV,clf_chrY_snps,ofh_new)    
-    # classify_dataframe(df_male_nonPAR_X_indel,clf_chrX_chrY_indels,ofh_new)    
+    # classify_dataframe(df_male_nonPAR_Y_SNV,clf_chrY_snps,ofh_new)
+    # classify_dataframe(df_male_nonPAR_X_indel,clf_chrX_chrY_indels,ofh_new)
     # classify_dataframe(df_male_nonPAR_Y_indel,clf_chrX_chrY_indels,ofh_new)
     # classify_dataframe(df_male_PAR_X_SNV,clf,ofh_new)
     # classify_dataframe(df_male_PAR_Y_SNV,clf,ofh_new)
     # classify_dataframe(df_male_PAR_X_indel,clf_indels,ofh_new)
     # classify_dataframe(df_male_PAR_Y_indel,clf_indels,ofh_new)
-   
+
     ofb = feature_file_parent_stem + ".preds.bed"
-    fout = open(ofb,"w")
-    f = open(ofh,"r")
-    make_output_bed(f = f, fout = fout)
-    
-def make_output_bed(f = None, fout = None):
+    fout = open(ofb, "w")
+    f = open(ofh, "r")
+    make_output_bed(f=f, fout=fout)
+
+
+def make_output_bed(f=None, fout=None):
     f.readline()
     for line in f:
         linesplit = line.rstrip().split("\t")
-        chrom,pos,ref,alt,iid,pred,prob = linesplit[0],linesplit[1],linesplit[3],linesplit[4],linesplit[5],linesplit[-2],linesplit[-1]
-        pos_0 = str(int(pos)-1)
-        pos_1= str(int(pos) + len(ref) - 1)
-        ID_column = "{}:{}:{}:{}:{}:{}:{}".format(chrom,pos,ref,alt,iid,pred,prob)
-        row = "{}\t{}\t{}\t{}\n".format(chrom,pos_0,pos_1,ID_column)
+        chrom, pos, ref, alt, iid, pred, prob = (
+            linesplit[0],
+            linesplit[1],
+            linesplit[3],
+            linesplit[4],
+            linesplit[5],
+            linesplit[-2],
+            linesplit[-1],
+        )
+        pos_0 = str(int(pos) - 1)
+        pos_1 = str(int(pos) + len(ref) - 1)
+        ID_column = "{}:{}:{}:{}:{}:{}:{}".format(chrom, pos, ref, alt, iid, pred, prob)
+        row = "{}\t{}\t{}\t{}\n".format(chrom, pos_0, pos_1, ID_column)
         fout.write(row)
+
 
 if __name__ == "__main__":
     import warnings
+
     warnings.filterwarnings("ignore")
     import argparse
+
     parser = argparse.ArgumentParser(usage=__usage__)
     # Necessary arguments
-    parser.add_argument("-d","--features",required=True)
-    parser.add_argument("-f","--fam",required=True)
+    parser.add_argument("-d", "--features", required=True)
+    parser.add_argument("-f", "--fam", required=True)
     # Optional arguments
-    parser.add_argument("-s","--snp_classifier",required=False)
-    parser.add_argument("-i","--indel_classifier",required=False)
-    parser.add_argument('-p',"--keep_all_putative_dnms", action='store_true')    
-    args  = parser.parse_args()
-
+    parser.add_argument("-s", "--snp_classifier", required=False)
+    parser.add_argument("-i", "--indel_classifier", required=False)
+    parser.add_argument("-p", "--keep_all_putative_dnms", action="store_true")
+    args = parser.parse_args()
 
     # feature_filename = sys.argv[1]
     feature_filename = args.features
@@ -189,11 +249,19 @@ if __name__ == "__main__":
 
     if args.snp_classifier:
         snv_clf_filename = args.s
-    else: snv_clf_filename = "snp_100-12-10-2-1-0.0-100.joblib"
+    else:
+        snv_clf_filename = "snp_100-12-10-2-1-0.0-100.joblib"
     if args.indel_classifier:
         indel_clf_filename = args.i
-    else: indel_clf_filename = "indel_1000-12-25-2-1-0.0-100.joblib"
+    else:
+        indel_clf_filename = "indel_1000-12-25-2-1-0.0-100.joblib"
 
     keep_fp = args.keep_all_putative_dnms
 
-    classify(feature_table = feature_filename, fam_fh = ped_filename, clf_snv = snv_clf_filename, clf_indel = indel_clf_filename, keep_fp = keep_fp)
+    classify(
+        feature_table=feature_filename,
+        fam_fh=ped_filename,
+        clf_snv=snv_clf_filename,
+        clf_indel=indel_clf_filename,
+        keep_fp=keep_fp,
+    )

--- a/synthdnm/vcf.py
+++ b/synthdnm/vcf.py
@@ -1,87 +1,171 @@
 from .backend import tokenize
 import numpy as np
+import sys
+
 
 def index_samples(CHROM_header_line, ped_dictionary):
     """Processes CHROM header line and stores column indices with sample ID"""
     iid_indices = {}  # iid_indices[iid] = index
-    linesplit = tokenize(CHROM_header_line) 
+    linesplit = tokenize(CHROM_header_line)
     for i in range(9, len(linesplit)):
-        iid = linesplit[i] # The sample ID (IID) at the ith column
+        iid = linesplit[i]  # The sample ID (IID) at the ith column
         iid_indices[iid] = i
     return iid_indices
+
 
 def index_format(FORMAT):
     """Determines indices of FORMAT values"""
     format_indices = {}
     fields = FORMAT.split(":")
-    for i in range(0, len(fields)): 
+    for i in range(0, len(fields)):
         field = fields[i]
         format_indices[field] = i
-    return format_indices 
+    return format_indices
+
 
 def get_feature(iid_feature_index, format_index):
     """Gets feature value at format_index"""
-    if format_index >= len(iid_feature_index.split(":")): return None 
+    if format_index >= len(iid_feature_index.split(":")):
+        return None
     return iid_feature_index.split(":")[format_index]
+
 
 def get_info_features(info_keys, info_column):
     """Get info features for variant"""
-    info_features = {key: None for key in info_keys} # Initialize each key's value to None
+    info_features = {
+        key: None for key in info_keys
+    }  # Initialize each key's value to None
     for field in info_column.split(";"):
-        if "=" not in field: continue
-        key,val = field.split("=")
-        if key not in info_keys: continue
-        else: info_features[key] = val
+        if "=" not in field:
+            continue
+        key, val = field.split("=")
+        if key not in info_keys:
+            continue
+        else:
+            info_features[key] = val
     return info_features
 
-def parse_variant(line,ped_dict,iid_indices,info_keys, fout=None, training_examples = None):
+
+def parse_variant(
+    line, ped_dict, iid_indices, info_keys, fout=None, training_examples=None
+):
     """Parse line for variant"""
     linesplit = tokenize(line)
-    variant = tuple(map(str,linesplit[0:5]))
-    chrom,pos,ref,alt = variant[0],variant[1],variant[3],variant[4]
-    start,end = int(pos)-1,int(pos)+len(ref)-1 # Zero-based positions
-    ID = "{}:{}:{}:{}".format(chrom,start,end,ref,alt) # chrom:start:end:ref:alt
+    variant = tuple(map(str, linesplit[0:5]))
+    chrom, pos, ref, alt = variant[0], variant[1], variant[3], variant[4]
+    start, end = int(pos) - 1, int(pos) + len(ref) - 1  # Zero-based positions
+    ID = "{}:{}:{}:{}".format(chrom, start, end, ref, alt)  # chrom:start:end:ref:alt
 
     # Skip multiallelic variants
     n_alt = len(alt.split(","))
-    if n_alt > 1: return
+    if n_alt > 1:
+        return
 
     # Skip X and Y variants for now
-    if "X" in chrom or "Y" in chrom: return
+    if "X" in chrom or "Y" in chrom:
+        return
 
     INFO = linesplit[7]
     info_features = get_info_features(info_keys, INFO)
 
-    format_indices = index_format(FORMAT = linesplit[8]) # Genotype FORMAT field (contains GT, DP, etc.)
-    # According to doc, none of the fields in the FORMAT column are required 
+    format_indices = index_format(
+        FORMAT=linesplit[8]
+    )  # Genotype FORMAT field (contains GT, DP, etc.)
+    # According to doc, none of the fields in the FORMAT column are required
     # We should require GT, GQ, PL, AD, DP?
+    required_format_fields = ["GT", "GQ", "PL", "AD", "DP"]
+    if not all(field in format_indices for field in required_format_fields):
+        print(
+            "Variant is missing a required field; skipping [{}]".format(ID),
+            file=sys.stderr,
+        )
+        return
 
     for offspring_iid in ped_dict:
-        father_iid, mother_iid = ped_dict[offspring_iid][2],ped_dict[offspring_iid][3]
-        if offspring_iid not in iid_indices or father_iid not in iid_indices or mother_iid not in iid_indices: continue
-        offspring_GT,father_GT,mother_GT = get_feature(linesplit[iid_indices[offspring_iid]],format_indices["GT"]),get_feature(linesplit[iid_indices[father_iid]],format_indices["GT"]),get_feature(linesplit[iid_indices[mother_iid]],format_indices["GT"])
-        offspring_AD,father_AD,mother_AD = get_feature(linesplit[iid_indices[offspring_iid]],format_indices["AD"]),get_feature(linesplit[iid_indices[father_iid]],format_indices["AD"]),get_feature(linesplit[iid_indices[mother_iid]],format_indices["AD"]) 
-        offspring_DP,father_DP,mother_DP = get_feature(linesplit[iid_indices[offspring_iid]],format_indices["DP"]),get_feature(linesplit[iid_indices[father_iid]],format_indices["DP"]),get_feature(linesplit[iid_indices[mother_iid]],format_indices["DP"])
-        offspring_GQ,father_GQ,mother_GQ = get_feature(linesplit[iid_indices[offspring_iid]],format_indices["GQ"]),get_feature(linesplit[iid_indices[father_iid]],format_indices["GQ"]),get_feature(linesplit[iid_indices[mother_iid]],format_indices["GQ"])
-        offspring_PL,father_PL,mother_PL = get_feature(linesplit[iid_indices[offspring_iid]],format_indices["PL"]),get_feature(linesplit[iid_indices[father_iid]],format_indices["PL"]),get_feature(linesplit[iid_indices[mother_iid]],format_indices["PL"])
+        father_iid, mother_iid = ped_dict[offspring_iid][2], ped_dict[offspring_iid][3]
+        if (
+            offspring_iid not in iid_indices
+            or father_iid not in iid_indices
+            or mother_iid not in iid_indices
+        ):
+            continue
+        offspring_GT, father_GT, mother_GT = (
+            get_feature(linesplit[iid_indices[offspring_iid]], format_indices["GT"]),
+            get_feature(linesplit[iid_indices[father_iid]], format_indices["GT"]),
+            get_feature(linesplit[iid_indices[mother_iid]], format_indices["GT"]),
+        )
+        offspring_AD, father_AD, mother_AD = (
+            get_feature(linesplit[iid_indices[offspring_iid]], format_indices["AD"]),
+            get_feature(linesplit[iid_indices[father_iid]], format_indices["AD"]),
+            get_feature(linesplit[iid_indices[mother_iid]], format_indices["AD"]),
+        )
+        offspring_DP, father_DP, mother_DP = (
+            get_feature(linesplit[iid_indices[offspring_iid]], format_indices["DP"]),
+            get_feature(linesplit[iid_indices[father_iid]], format_indices["DP"]),
+            get_feature(linesplit[iid_indices[mother_iid]], format_indices["DP"]),
+        )
+        offspring_GQ, father_GQ, mother_GQ = (
+            get_feature(linesplit[iid_indices[offspring_iid]], format_indices["GQ"]),
+            get_feature(linesplit[iid_indices[father_iid]], format_indices["GQ"]),
+            get_feature(linesplit[iid_indices[mother_iid]], format_indices["GQ"]),
+        )
+        offspring_PL, father_PL, mother_PL = (
+            get_feature(linesplit[iid_indices[offspring_iid]], format_indices["PL"]),
+            get_feature(linesplit[iid_indices[father_iid]], format_indices["PL"]),
+            get_feature(linesplit[iid_indices[mother_iid]], format_indices["PL"]),
+        )
 
         # (Maybe later allow for 0/1,1/1,1/1 genotypes)
-        if not (offspring_GT.replace("|","/") == "0/1" and father_GT.replace("|","/") == "0/0" and mother_GT.replace("|","/") == "0/0"): continue
-        if (offspring_PL is None or father_PL is None or mother_PL is None): continue
-        # Get genotype features  
-        offspring_PL,father_PL,mother_PL = offspring_PL.split(","),father_PL.split(","),mother_PL.split(",")
-        (offspring_hom_ref_pl,offspring_het_pl,offspring_hom_alt_pl) = (offspring_PL[0],offspring_PL[1],offspring_PL[2])
-        (father_hom_ref_pl,father_het_pl,father_hom_alt_pl) = (father_PL[0],father_PL[1],father_PL[2])
-        (mother_hom_ref_pl,mother_het_pl,mother_hom_alt_pl) = (mother_PL[0],mother_PL[1],mother_PL[2])
+        if not (
+            offspring_GT.replace("|", "/") == "0/1"
+            and father_GT.replace("|", "/") == "0/0"
+            and mother_GT.replace("|", "/") == "0/0"
+        ):
+            continue
+        if offspring_PL is None or father_PL is None or mother_PL is None:
+            continue
+        # Get genotype features
+        offspring_PL, father_PL, mother_PL = (
+            offspring_PL.split(","),
+            father_PL.split(","),
+            mother_PL.split(","),
+        )
+        (offspring_hom_ref_pl, offspring_het_pl, offspring_hom_alt_pl) = (
+            offspring_PL[0],
+            offspring_PL[1],
+            offspring_PL[2],
+        )
+        (father_hom_ref_pl, father_het_pl, father_hom_alt_pl) = (
+            father_PL[0],
+            father_PL[1],
+            father_PL[2],
+        )
+        (mother_hom_ref_pl, mother_het_pl, mother_hom_alt_pl) = (
+            mother_PL[0],
+            mother_PL[1],
+            mother_PL[2],
+        )
 
-        (parent_min_DNM_PL, parent_max_DNM_PL) = sorted(np.array([father_het_pl,mother_het_pl], dtype=np.float64))
-        (parent_min_HOM_REF_PL, parent_max_HOM_REF_PL) = sorted(np.array([father_hom_ref_pl,mother_hom_ref_pl], dtype=np.float64))
+        (parent_min_DNM_PL, parent_max_DNM_PL) = sorted(
+            np.array([father_het_pl, mother_het_pl], dtype=np.float64)
+        )
+        (parent_min_HOM_REF_PL, parent_max_HOM_REF_PL) = sorted(
+            np.array([father_hom_ref_pl, mother_hom_ref_pl], dtype=np.float64)
+        )
 
         offspring_ar = get_offspring_ar(offspring_AD)
-        offspring_DP_,father_DP_,mother_DP_ = get_log2_coverage_ratio(offspring_AD),get_log2_coverage_ratio(father_AD),get_log2_coverage_ratio(mother_AD)
-        (parent_min_DP,parent_max_DP) = sorted(np.array([father_DP_,mother_DP_], dtype=np.float64))
-        (parent_min_GQ,parent_max_GQ) = sorted(np.array([father_GQ,mother_GQ], dtype=np.float64))
-       
+        offspring_DP_, father_DP_, mother_DP_ = (
+            get_log2_coverage_ratio(offspring_AD),
+            get_log2_coverage_ratio(father_AD),
+            get_log2_coverage_ratio(mother_AD),
+        )
+        (parent_min_DP, parent_max_DP) = sorted(
+            np.array([father_DP_, mother_DP_], dtype=np.float64)
+        )
+        (parent_min_GQ, parent_max_GQ) = sorted(
+            np.array([father_GQ, mother_GQ], dtype=np.float64)
+        )
+
         filter_ = None
         qual = None
 
@@ -89,95 +173,201 @@ def parse_variant(line,ped_dict,iid_indices,info_keys, fout=None, training_examp
         parent_ar_min = 0
 
         # fout line with features
-        feats = [offspring_GT, father_GT, mother_GT,\
-                 n_alt, filter_, qual,\
-                 parent_ar_max, parent_ar_min, offspring_ar,\
-                 parent_max_DP, parent_min_DP, offspring_DP_,\
-                 parent_max_DNM_PL, parent_min_DNM_PL,\
-                 parent_max_HOM_REF_PL, parent_min_HOM_REF_PL,\
-                 offspring_het_pl, offspring_hom_ref_pl,\
-                 parent_max_GQ, parent_min_GQ, offspring_GQ] + list(info_features.values())
+        feats = [
+            offspring_GT,
+            father_GT,
+            mother_GT,
+            n_alt,
+            filter_,
+            qual,
+            parent_ar_max,
+            parent_ar_min,
+            offspring_ar,
+            parent_max_DP,
+            parent_min_DP,
+            offspring_DP_,
+            parent_max_DNM_PL,
+            parent_min_DNM_PL,
+            parent_max_HOM_REF_PL,
+            parent_min_HOM_REF_PL,
+            offspring_het_pl,
+            offspring_hom_ref_pl,
+            parent_max_GQ,
+            parent_min_GQ,
+            offspring_GQ,
+        ] + list(info_features.values())
 
-        out = "{}\t{}\t{}\t{}\t{}\t{}".format(chrom,pos,ID,ref,alt,offspring_iid) + "\t" + "\t".join([str(elem) for elem in feats])
-        if training_examples: out = out + "\t" + training_examples
+        out = (
+            "{}\t{}\t{}\t{}\t{}\t{}".format(chrom, pos, ID, ref, alt, offspring_iid)
+            + "\t"
+            + "\t".join([str(elem) if elem is not None else "" for elem in feats])
+        )
+        if training_examples:
+            out = out + "\t" + training_examples
         if fout:
             print(out, file=fout)
-        else: print(out)
+        else:
+            print(out)
 
-       
+
 def get_offspring_ar(offspring_AD):
     # Add one to avoid 0 values in the denominator
     _buff = 1
-    ref_AD,alt_AD = offspring_AD.split(",")[0],offspring_AD.split(",")[1]
-    if ref_AD is None or alt_AD is None: return None
-    offspring_AR = float(alt_AD)/(float(ref_AD) + _buff)
+    ref_AD, alt_AD = offspring_AD.split(",")[0], offspring_AD.split(",")[1]
+    if ref_AD is None or alt_AD is None:
+        return None
+    offspring_AR = float(alt_AD) / (float(ref_AD) + _buff)
     return offspring_AR
 
 
 def get_log2_coverage_ratio(AD):
     _buff = 1
-    ref_AD,alt_AD = float(AD.split(",")[0]),float(AD.split(",")[1])
-    if ref_AD is None or alt_AD is None: return None
-    coverage_ratio = np.log2((ref_AD + alt_AD + _buff) / (np.median([ref_AD,alt_AD]) + _buff))
+    ref_AD, alt_AD = float(AD.split(",")[0]), float(AD.split(",")[1])
+    if ref_AD is None or alt_AD is None:
+        return None
+    coverage_ratio = np.log2(
+        (ref_AD + alt_AD + _buff) / (np.median([ref_AD, alt_AD]) + _buff)
+    )
     return coverage_ratio
 
 
-def parse(vcf_filepath, ped_filepath, info_keys, variants_to_keep = None, fout = None, training_examples = None):
+def parse(
+    vcf_filepath,
+    ped_filepath,
+    info_keys,
+    variants_to_keep=None,
+    fout=None,
+    training_examples=None,
+):
     from .backend import process_ped
+
     ped_dict = process_ped(ped_filepath)
 
     # The INFO column depends on the VCF type
-    header = "\t".join(["chrom","pos","ID","ref","alt","iid"] +\
-                       ["offspring_gt", "father_gt", "mother_gt", "nalt", "filter", "qual", "parent_ar_max", "parent_ar_min", "offspring_ar", "parent_dp_max", "parent_dp_min", "offspring_dp", "parent_dnm_pl_max", "parent_dnm_pl_min", "parent_inh_pl_max", "parent_inh_pl_min", "offspring_dnm_pl", "offspring_inh_pl", "parent_gq_max", "parent_gq_min", "offspring_gq"] +\
-                       info_keys)
-    if training_examples: header = header + "\t" + "TRUTH"
-    if fout: 
-        if fout.tell() == 0: print(header,file=fout)
-    else: print(header)
+    header = "\t".join(
+        ["chrom", "pos", "ID", "ref", "alt", "iid"]
+        + [
+            "offspring_gt",
+            "father_gt",
+            "mother_gt",
+            "nalt",
+            "filter",
+            "qual",
+            "parent_ar_max",
+            "parent_ar_min",
+            "offspring_ar",
+            "parent_dp_max",
+            "parent_dp_min",
+            "offspring_dp",
+            "parent_dnm_pl_max",
+            "parent_dnm_pl_min",
+            "parent_inh_pl_max",
+            "parent_inh_pl_min",
+            "offspring_dnm_pl",
+            "offspring_inh_pl",
+            "parent_gq_max",
+            "parent_gq_min",
+            "offspring_gq",
+        ]
+        + info_keys
+    )
+    if training_examples:
+        header = header + "\t" + "TRUTH"
+    if fout:
+        if fout.tell() == 0:
+            print(header, file=fout)
+    else:
+        print(header)
 
     if vcf_filepath.endswith(".gz"):
         import gzip
-        f = gzip.open(vcf_filepath,"rt",9)
-    else: f = open(vcf_filepath,"r")
+
+        f = gzip.open(vcf_filepath, "rt", 9)
+    else:
+        f = open(vcf_filepath, "r")
 
     for line in f:
-        if line.startswith("#CHROM"): iid_indices = index_samples(line, ped_dict) # Use the CHROM header line to index the samples
-        if line.startswith("#"): continue
-        parse_variant(line, ped_dict, iid_indices, info_keys, fout=fout, training_examples=training_examples)
-
+        if line.startswith("#CHROM"):
+            iid_indices = index_samples(
+                line, ped_dict
+            )  # Use the CHROM header line to index the samples
+        if line.startswith("#"):
+            continue
+        parse_variant(
+            line,
+            ped_dict,
+            iid_indices,
+            info_keys,
+            fout=fout,
+            training_examples=training_examples,
+        )
 
 
 ###
-def parse_private_inherited_variant(line,ped_dict,iid_indices,fout):
+def parse_private_inherited_variant(line, ped_dict, iid_indices, fout):
     """Parse line for variant"""
     linesplit = tokenize(line)
-    variant = tuple(map(str,linesplit[0:5]))
-    chrom,pos,ref,alt = variant[0],variant[1],variant[3],variant[4]
-    start,end = int(pos)-1,int(pos)+len(ref)-1 # Zero-based positions
-    ID = "{}:{}:{}:{}".format(chrom,start,end,ref,alt) # chrom:start:end:ref:alt
-    format_indices = index_format(FORMAT = linesplit[8]) # Genotype FORMAT field (contains GT, DP, etc.)
+    variant = tuple(map(str, linesplit[0:5]))
+    chrom, pos, ref, alt = variant[0], variant[1], variant[3], variant[4]
+    start, end = int(pos) - 1, int(pos) + len(ref) - 1  # Zero-based positions
+    ID = "{}:{}:{}:{}".format(chrom, start, end, ref, alt)  # chrom:start:end:ref:alt
+    format_indices = index_format(
+        FORMAT=linesplit[8]
+    )  # Genotype FORMAT field (contains GT, DP, etc.)
     for offspring_iid in ped_dict:
-        father_iid, mother_iid = ped_dict[offspring_iid][2],ped_dict[offspring_iid][3]
-        if offspring_iid not in iid_indices or father_iid not in iid_indices or mother_iid not in iid_indices: continue
-        offspring_GT,father_GT,mother_GT = get_feature(linesplit[iid_indices[offspring_iid]],format_indices["GT"]),get_feature(linesplit[iid_indices[father_iid]],format_indices["GT"]),get_feature(linesplit[iid_indices[mother_iid]],format_indices["GT"])
+        father_iid, mother_iid = ped_dict[offspring_iid][2], ped_dict[offspring_iid][3]
+        if (
+            offspring_iid not in iid_indices
+            or father_iid not in iid_indices
+            or mother_iid not in iid_indices
+        ):
+            continue
+        offspring_GT, father_GT, mother_GT = (
+            get_feature(linesplit[iid_indices[offspring_iid]], format_indices["GT"]),
+            get_feature(linesplit[iid_indices[father_iid]], format_indices["GT"]),
+            get_feature(linesplit[iid_indices[mother_iid]], format_indices["GT"]),
+        )
         # (Maybe later allow for 0/1,1/1,1/1 genotypes)
-        if (offspring_GT.replace("|","/") == "0/1" and father_GT.replace("|","/") == "0/1" and mother_GT.replace("|","/") == "0/0") or (offspring_GT.replace("|","/") == "0/1" and father_GT.replace("|","/") == "0/0" and mother_GT.replace("|","/") == "0/1"): 
-                # print("{}\t{}\t{}\t{}".format(ID,offspring_iid,father_iid,mother_iid))
-                fout.write("{}\t{}\t{}\t{}\t{}\t{}\t{}\n".format(ID,offspring_iid,father_iid,mother_iid,offspring_GT,father_GT,mother_GT))
-    
+        if (
+            offspring_GT.replace("|", "/") == "0/1"
+            and father_GT.replace("|", "/") == "0/1"
+            and mother_GT.replace("|", "/") == "0/0"
+        ) or (
+            offspring_GT.replace("|", "/") == "0/1"
+            and father_GT.replace("|", "/") == "0/0"
+            and mother_GT.replace("|", "/") == "0/1"
+        ):
+            # print("{}\t{}\t{}\t{}".format(ID,offspring_iid,father_iid,mother_iid))
+            fout.write(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\n".format(
+                    ID,
+                    offspring_iid,
+                    father_iid,
+                    mother_iid,
+                    offspring_GT,
+                    father_GT,
+                    mother_GT,
+                )
+            )
 
 
 def parse_private_inherited(vcf_filepath, ped_filepath):
     from .backend import process_ped
+
     ped_dict = process_ped(ped_filepath)
     if vcf_filepath.endswith(".gz"):
         import gzip
-        f = gzip.open(vcf_filepath,"rt",9)
-    else: f = open(vcf_filepath,"r")
 
-    fout = open("private_transmitted_IDs.txt","w")
+        f = gzip.open(vcf_filepath, "rt", 9)
+    else:
+        f = open(vcf_filepath, "r")
+
+    fout = open("private_transmitted_IDs.txt", "w")
     for line in f:
-        if line.startswith("#CHROM"): iid_indices = index_samples(line, ped_dict) # Use the CHROM header line to index the samples
-        if line.startswith("#"): continue
+        if line.startswith("#CHROM"):
+            iid_indices = index_samples(
+                line, ped_dict
+            )  # Use the CHROM header line to index the samples
+        if line.startswith("#"):
+            continue
         parse_private_inherited_variant(line, ped_dict, iid_indices, fout)
-


### PR DESCRIPTION
These changes allow for tab- and space-delimited PEDs to be used.

Variants that are missing a FORMAT field that is required to calculate a feature are skipped; their IDs are output to `stderr`.

Features that are set to `None` (e.g. `filter` and `quality`) are converted to empty strings rather than `str(None)` when writing features out to avoid issues later when loading feats in via `numpy`.